### PR TITLE
Use port number taken from the .env in the generate Entities() function

### DIFF
--- a/bin/commander.js
+++ b/bin/commander.js
@@ -131,6 +131,7 @@ class Commander
             '--user='+process.env.RELDENS_DB_USER,
             '--pass='+process.env.RELDENS_DB_PASSWORD,
             '--host='+process.env.RELDENS_DB_HOST,
+            '--port='+process.env.RELDENS_DB_PORT,			
             '--database='+process.env.RELDENS_DB_NAME,
             '--driver='+(process.env.RELDENS_STORAGE_DRIVER || 'objection-js'),
             '--client='+process.env.RELDENS_DB_CLIENT


### PR DESCRIPTION
The generateEntities() function always used the default port 3306, regardless of the port specified in the environment variables. The necessary line has been added to use the RELDENS_DB_PORT value.